### PR TITLE
PKG-5720

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,24 +1,18 @@
 cross_target_platform:
-  - linux-64                            # [linux]
-  - linux-aarch64                       # [linux]
-  - linux-ppc64le                       # [linux]
-  - osx-64                              # [linux or (osx and x86_64) or (osx and arm64)]
-  - osx-arm64                           # [linux or (osx and x86_64) or (osx and arm64)]
-  - win-64                              # [linux64 or win]
+  - linux-64                            # [linux and x86_64]
+  - linux-aarch64                       # [linux and aarch64]
+  - linux-s390x                         # [linux and s390x]
+  - osx-64                              # [osx and x86_64]
+  - osx-arm64                           # [osx and arm64]
+  - win-64                              # [win and x86_64]
 GOOS:
   - linux                               # [linux]
-  - linux                               # [linux]
-  - linux                               # [linux]
-  - darwin                              # [linux or (osx and x86_64) or (osx and arm64)]
-  - darwin                              # [linux or (osx and x86_64) or (osx and arm64)]
-  - windows                             # [linux64 or win]
+  - darwin                              # [osx]
+  - windows                             # [win]
 GOARCH:
-  - amd64                               # [linux]
-  - arm64                               # [linux]
-  - ppc64le                             # [linux]
-  - amd64                               # [linux or (osx and x86_64) or (osx and arm64)]
-  - arm64                               # [linux or (osx and x86_64) or (osx and arm64)]
-  - amd64                               # [linux64 or win]
+  - amd64                               # [x86_64]
+  - arm64                               # [aarch64 or arm64]
+  - s390x                               # [s390x]
 go_variant_str:
   - cgo
   - nocgo

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,16 +15,18 @@ source:
 
 build:
   number: 0
-  run_exports:   # [cross_target_platform == "osx-64"]
-    strong_constrains:   # [cross_target_platform == "osx-64"]
-      - __osx>=10.12    # [cross_target_platform == "osx-64"]
-  run_exports:   # [cross_target_platform == "linux-64" and go_variant_str == "cgo"]
-    strong:   # [cross_target_platform == "linux-64" and go_variant_str == "cgo"]
-      - __glibc >=2.17                    # [cross_target_platform == "linux-64" and go_variant_str == "cgo"]
+  skip: True            # [s390x]
+  run_exports:          # [osx]
+    strong_constrains:  # [osx]
+      - __osx>=10.12    # [osx]
+  run_exports:          # [linux and go_variant_str == "cgo"]
+    strong:             # [linux and go_variant_str == "cgo"]
+      - __glibc >=2.17  # [linux and go_variant_str == "cgo"]
 
 requirements:
   build:
-    - sed  # [osx]
+    - sed        # [osx]
+    - coreutils  # [osx]
   run:
     - go {{ version }}.*
     - _go_select =={{ go_variant_ver }}={{ go_variant_str }}
@@ -34,7 +36,7 @@ test:
     - hello_world.go
 
 about:
-  home: http://golang.org
+  home: https://golang.org
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
@@ -46,10 +48,10 @@ about:
     values are ignored if GOBIN and GOPATH environment variables 
     are set independently by the user.
 
-    Futhermore, this package set the correct GOARCH and GOOS
+    Furthermore, this package set the correct GOARCH and GOOS
     environment variables to enable cross-compilation.
-  doc_url: https://golang.org/doc
-  dev_url: https://go.googlesource.com/go
+  doc_url: https://go.dev/doc
+  dev_url: https://github.com/golang/go
 
 extra:
   feedstock-name: go-activation

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -17,7 +17,19 @@ test "$(go env GOBIN)" == "$CONDA_PREFIX/bin"
 # Test GOPATH is set to SRC-DIR
 # We cannot use that here though as conda-build checks for
 # the existence of SRC-DIR for an old behaviour change.
-test "$(go env GOPATH)" == "${PWD}/gopath"
+#
+# Resolve GOPATH symlinks. This is particularly an issue in
+# CI on OSX with /var being a symlink to /private/var.
+if [[ "${build_platform:0:3}" == "osx" ]]; then
+  gopath=$(go env GOPATH)
+  if [[ ! -f "${gopath}" ]]; then
+    # readlink doesn't work if the target doesn't exist.
+    mkdir -p "${gopath}"
+  fi
+  test "$(readlink -f ${gopath})" == "${PWD}/gopath"
+else
+  test "$(go env GOPATH)" == "${PWD}/gopath"
+fi
 
 
 # Print diagnostics


### PR DESCRIPTION
go-activation 1.21.5

**Destination channel:** defaults

### Links

- [PKG-5720](https://anaconda.atlassian.net/browse/PKG-5720)
- [Upstream repository](https://github.com/golang/go/tree/go1.21.5)
- [Upstream changelog/diff](https://github.com/golang/go/compare/go1.21.4...go1.21.5)
- Relevant dependency PRs:
  - AnacondaRecipes/fzf-feedstock#1
  - AnacondaRecipes/go-licenses-feedstock#1

### Explanation of changes:

- Updated path tests for OSX since our environment's `pwd` always resolves symlinks
- Updated metadata links


[PKG-5720]: https://anaconda.atlassian.net/browse/PKG-5720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ