### PR TITLE
go-activation-1.25.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.21.5" %}
+{% set version = "1.25.8" %}
 
 {% if cross_target_platform is undefined %}
 {% set cross_target_platform = "foo" %}
@@ -11,7 +11,7 @@ package:
 source:
   # Add a source we don't need so that the bot issues PRs here automatically.
   url: https://dl.google.com/go/go{{ version }}.src.tar.gz
-  sha256: 285cbbdf4b6e6e62ed58f370f3f6d8c30825d6e56c5853c66d3c23bcdb09db19
+  sha256: e988d4a2446ac7fe3f6daa089a58e9936a52a381355adec1c8983230a8d6c59e
 
 build:
   number: 0


### PR DESCRIPTION
go-activation 1.25.8

**Destination channel:** defaults

### Links

- jira: https://anaconda.atlassian.net/browse/PKG-13307
- [Upstream repository](https://github.com/golang/go/tree/go1.25.8)
- [Upstream changelog/diff](https://github.com/golang/go/compare/go1.25.4...go1.25.8)
- Relevant dependency PRs:
  - AnacondaRecipes/go-feedstock#23

### Explanation of changes:

- bump version