### PR TITLE
v1.26.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/go-feedstock/pr25/b7bb36e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/go-feedstock/pr25/b7bb36e

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.25.8" %}
+{% set version = "1.26.2" %}
 
 {% if cross_target_platform is undefined %}
 {% set cross_target_platform = "foo" %}
@@ -11,7 +11,7 @@ package:
 source:
   # Add a source we don't need so that the bot issues PRs here automatically.
   url: https://dl.google.com/go/go{{ version }}.src.tar.gz
-  sha256: e988d4a2446ac7fe3f6daa089a58e9936a52a381355adec1c8983230a8d6c59e
+  sha256: 2e91ebb6947a96e9436fb2b3926a8802efe63a6d375dffec4f82aa9dbd6fd43b
 
 build:
   number: 0


### PR DESCRIPTION
go v1.26.2

**Destination channel:** {Snowflake | defaults}

### Links

- [PKG-13508](https://anaconda.atlassian.net/browse/PKG-13508) 
- [Upstream repository](https://github.com/golang/go/tree/go1.26.2)
- [Upstream changelog/diff](https://github.com/golang/go/issues?q=milestone%3AGo1.26.2+label%3ACherryPickApproved)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/go-activation-feedstock/pull/3

### Explanation of changes:

- Bump version and SHAs

abs.yaml will be removed before merging 

[PKG-13508]: https://anaconda.atlassian.net/browse/PKG-13508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ